### PR TITLE
Added dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+- package-ecosystem: cargo
+  directory: "/"
+  schedule:
+    interval: daily


### PR DESCRIPTION
I'm wondering if dependabot cannot see the phaselock repository because this repository has no dependabot.yml. Going to try to add this here to see if this fixes the phaselock repository. This should probably not be merged upstream (or maybe it should, I'm not sure)